### PR TITLE
[add] 秘密の呪文入力判定、トップページ遷移

### DIFF
--- a/app/Http/Controllers/PseudoPageController.php
+++ b/app/Http/Controllers/PseudoPageController.php
@@ -6,9 +6,24 @@ use Illuminate\Http\Request;
 
 class PseudoPageController extends Controller
 {
-    // 職場閲覧モードランディングページ
+    // 偽ランディングページを表示
     public function index()
     {
         return view('pseudo_page.index');
+    }
+
+    // 秘密の呪文入力受付
+    public function post(Request $request)
+    {
+        // 呪文が正しいかチェック
+        $magic_word = $request->input('keyword');
+        $correct_word = 'secret';
+        if ($magic_word === $correct_word) {
+            // 正しい場合は、秘密の呪文入力後のランディングページを表示
+            return view('trivia.index');
+        } else {
+            // 正しくない場合は、偽ランディングページを表示
+            return view('pseudo_page.index');
+        }
     }
 }

--- a/app/Http/Controllers/TriviaController.php
+++ b/app/Http/Controllers/TriviaController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class TriviaController extends Controller
+{
+    // ランディングページを表示
+    public function index()
+    {
+        return view('trivia.index');
+    }
+}

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -1,6 +1,7 @@
 <div class="sidebar">
     <div class="search">
-        <form action="#" method="get">
+        <form action={{ route('secret') }} method="post">
+            @csrf
             <input type="text" name="keyword" placeholder="example" value="">
             <input type="submit" value="検索">
         </form>

--- a/resources/views/trivia/index.blade.php
+++ b/resources/views/trivia/index.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app')
+
+@section('content')
+
+<h2>秘密</h2>
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PseudoPageController;
+use App\Http\Controllers\TriviaController;
 
 /*
 |--------------------------------------------------------------------------
@@ -16,3 +17,8 @@ use App\Http\Controllers\PseudoPageController;
 
 // ランディングページ
 Route::get('/', [PseudoPageController::class, 'index']);
+// 秘密の呪文入力判定
+Route::post('/secret', [PseudoPageController::class, 'post'])->name('secret');
+
+// ランディングページ
+Route::get('/work', [TriviaController::class, 'index'])->name('index');


### PR DESCRIPTION
偽ランディングページで秘密の呪文を入力すると、職場閲覧モードのトップページに遷移できるようにした。